### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5.0.0
 
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: node
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)** on 2025-09-04T02:52:29Z
